### PR TITLE
fix(e-tb): make tabbing more intuitive

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -2436,7 +2436,7 @@
     "description": "Expect toBe",
     "types": "typescript",
     "body": [
-      "expect($1).toBe($1);",
+      "expect($1).toBe($2);",
       "$0"
     ]
   },


### PR DESCRIPTION
By making it possible to add two different values, this PR makes the `e-tb` snippet more intuitive.