### PR TITLE
Fixes error in Material Icon Button snippet

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -1810,7 +1810,7 @@
     "description": "Circular Material button with a transparent background",
     "types": "typescript, html",
     "body": [
-      "<button mat-icon-button>%{text}</button>$0"
+      "<button mat-icon-button><mat-icon>${icon_name}</mat-icon></button>$0"
     ]
   },
   "Material Round Button": {


### PR DESCRIPTION
The current snippet does not work properly:
1) The snippet's placeholder syntax is wrong: `%{text}` while it should be `${text}`
2) The material icon button usage is wrong, as it expects a `<mat-icon>` element inside the button.