### PR TITLE
Update ng-component-value-accessor to not notify of changes

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -88,7 +88,7 @@
       "\t}",
       "",
       "\twriteValue(obj: any): void {",
-      "\t\tthis.value = obj;",
+      "\t\tthis._value = obj;",
       "\t}",
       "",
       "\tregisterOnChange(fn: any): void {",


### PR DESCRIPTION
To follow Angular's standard we shouldn't call `notifyChange` inside `writeValue` as it happens here, because we use `value` property instead of backing property `_value`.

Angular will actually call this method twice: once with `null` another with the correct value, but that's another story.