### PR TITLE
missing ',' in ng-material-module

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -321,7 +321,7 @@
       "\t\tCdkStepperModule,",
       "\t\tCdkTableModule,",
       "\t\tCdkTreeModule,",
-      "\t\tDragDropModule",
+      "\t\tDragDropModule,",
       "\t\t// Material",
       "\t\tMatAutocompleteModule,",
       "\t\tMatBadgeModule,",


### PR DESCRIPTION
Fixes:

Missed Comma after DragDropModule word at line number 324