### PR TITLE
fix(Material Table): incorrect syntax

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -2458,11 +2458,11 @@
     "body": [
       "<table mat-table #table [dataSource]=\"${dataSource}\">",
       "\t<ng-container matColumnDef=\"${column}\">",
-      "\t\t<th mat-header-cell *matHeaderCellDef> ${header} </th>",
-      "\t\t<td mat-cell *matCellDef=\"let row\"> {{row.${column}}} </td>",
+      "\t\t<mat-header-cell *matHeaderCellDef> ${header} </mat-header-cell>",
+      "\t\t<mat-cell *matCellDef=\"let row\"> {{row.${column}}} </mat-cell>",
       "\t</ng-container>",
-      "\t<tr mat-header-row *matHeaderRowDef=\"['${column}']\"></tr>",
-      "\t<tr mat-row *matRowDef=\"let row; columns: ['${column}'];\"></tr>",
+      "\t<mat-header-row *matHeaderRowDef=\"['${column}']\"></mat-header-row>",
+      "\t<mat-row *matRowDef=\"let row; columns: ['${column}'];\"></mat-row>",
       "</table>$0"
     ]
   },
@@ -2472,8 +2472,8 @@
     "types": "typescript, html",
     "body": [
       "<ng-container matColumnDef=\"${column}\">",
-      "\t<th mat-header-cell *matHeaderCellDef> ${header} </th>",
-      "\t<td mat-cell *matCellDef=\"let row\"> {{row.${column}}} </td>",
+      "\t<mat-header-cell *matHeaderCellDef> ${header} </mat-header-cell>",
+      "\t<mat-cell *matCellDef=\"let row\"> {{row.${column}}} </mat-cell>",
       "</ng-container>$0"
     ]
   },


### PR DESCRIPTION
`*matHeaderCellDef`, `*matCellDef` are correct, the usage of the `th, td, tr` was incorrect.

Fixes #131 

REF: https://material.angular.io/components/table/examples