### PR TITLE
[refactor] Update ng-pipe-decimal to ng-pipe-number

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -594,11 +594,11 @@
     ]
   },
   "Angular Decimal Pipe": {
-    "prefix": "ng-pipe-decimal",
-    "description": "Decimal pipe - Usage: number_expression &#x7c; decimal[:digitInfo]",
+    "prefix": "ng-pipe-number",
+    "description": "Decimal pipe - Usage: number_expression &#x7c; number[:digitInfo]",
     "types": "typescript, html",
     "body": [
-      "{{ ${variable} | decimal:${digitInfo} }}$0"
+      "{{ ${variable} | number:${digitInfo} }}$0"
     ]
   },
   "Angular Slice Pipe": {


### PR DESCRIPTION
ng-pipe-decimal is not supported for latest version of Angular. It has been replaced by ng-pipe-number